### PR TITLE
Make script compatible with python 2.5

### DIFF
--- a/README
+++ b/README
@@ -24,3 +24,20 @@ To install:
     1) Add a call to the script as part of your post-commit hook.  On Windows, the call will look like this:
         python.exe C:\<path_to_script>\postToHipChat.py -s "%REPOS%" -r %REV%
 
+Configuration:
+    Either specify config values on command line, or in a config file. The command line takes precendence over 
+    the config file.
+
+Command line:
+    -f / --config  : config file
+    -k / --room    : room name
+    -t / --token   : token name
+
+Config file format. All values are optional. The section must be called 'hipchat'.
+===============
+[hipchat]
+NAME=<name>
+ROOM=<room>
+TOKEN=<token>
+===============
+

--- a/hipchat-svn-post-commit.py
+++ b/hipchat-svn-post-commit.py
@@ -5,6 +5,10 @@
 # Scott Vitale
 # svvitale@gmail.com
 
+#
+# Set config values in code, command line, or config file
+#
+
 # This script is set to publish information after SVN commits to HipChat. 
 #
 # Required files/Application/services:
@@ -20,15 +24,19 @@ import getopt
 import urllib
 import urllib2
 import re
+import ConfigParser
 
 # Default room name
-room = "<room name>"
+ROOM = "<room name>"
 
 # Default token
-token = "<token>"
+TOKEN = "<token>"
 
 # Default chat user name
-user="Subversion"
+NAME="Subversion"
+
+# Default config
+CONFIG="/etc/svn/hipchat.cfg"
 
 # Default svnlook location
 svnlook="/usr/bin/svnlook"
@@ -74,14 +82,19 @@ def getCommitInfo( repo, revision ):
 	return chatMsg
 
 def main():
-        repository = False
         revision = False
+        repository = False
+        cmd_config = False
+        cmd_token = False
+        cmd_name = False
+        cmd_room = False
+
         try:
-                opts, args = getopt.getopt(sys.argv[1:], "r:s:k:t:u:", ["revision=", "repository=", "config=", "room=", "token=", "user="])
+                opts, args = getopt.getopt(sys.argv[1:], "r:s:f:k:t:u:", ["revision=", "repository=", "config=", "room=", "token=", "user="])
         except getopt.GetoptError, err:
                 print >>sys.stderr, str(err)
                 print "Usage:"
-                print "hipchat-svn-post-commit.py -r <revision> -s <repository> [-k room] [-t token] [-n name]"
+                print "hipchat-svn-post-commit.py -r <revision> -s <repository> [-f config] [-k room] [-t token] [-n name]"
                 sys.exit(1)
         for o, a in opts:
                 if o in ("-r", "--revision"):
@@ -89,11 +102,45 @@ def main():
                 elif o in ("-s", "--repository"):
                        repository = a
                 elif o in ("-k", "--room"):
-                       room = a
+                       cmd_room = a
                 elif o in ("-t", "--token"):
-                       token = a
+                       cmd_token = a
                 elif o in ("-n", "--name"):
-                       name = a
+                       cmd_name = a
+                elif o in ("-f", "--config"):
+                       cmd_config = a
+                       if not os.path.isfile(cmd_config):
+                                print "Config file does not exist:", cmd_config
+                                sys.exit(2)
+        # set defaults
+        token = TOKEN
+        name = NAME
+        room = ROOM
+
+        # config overrides defaultsif cmd_room:
+        if cmd_config:
+        	     config_file = cmd_config
+       	else:
+        	     config_file = CONFIG
+
+        if os.path.isfile(config_file):
+                config = ConfigParser.ConfigParser()
+                config.read(config_file)
+                if config.has_section('hipchat'):
+                        if config.has_option('hipchat', 'TOKEN'):
+                	            token = config.get('hipchat', 'TOKEN')
+                        if config.has_option('hipchat', 'NAME'):
+                	            name = config.get('hipchat', 'NAME')
+                        if config.has_option('hipchat', 'TOKEN'):
+                	            room = config.get('hipchat', 'ROOM')
+        
+        # cmd line overrides defaults and config
+        if cmd_token:
+        	     token = cmd_token
+        if cmd_name:
+        	     name = cmd_name
+        if cmd_room:
+        	     room = cmd_room
 
         if not revision:
                 print "Sepcify a revision with -r or --revision"

--- a/hipchat-svn-post-commit.py
+++ b/hipchat-svn-post-commit.py
@@ -25,6 +25,7 @@ import urllib
 import urllib2
 import re
 import ConfigParser
+import threading
 
 # Default room name
 ROOM = "<room name>"
@@ -63,6 +64,11 @@ def sendToHipChat( msg, token, room, name ):
 		'notify': 1,
 	}
 
+    t = threading.Thread(target=open_url)
+    t.daemon = True
+    t.start()
+
+def open_url():
 	# urlencode and post
 	urllib2.urlopen( "https://api.hipchat.com/v1/rooms/message", urllib.urlencode( request ) )
   

--- a/hipchat-svn-post-commit.py
+++ b/hipchat-svn-post-commit.py
@@ -64,9 +64,9 @@ def getCommitInfo( repo, revision ):
 	files = runLook("changed", repo, "-r", revision)
 
 	chatMsg = ("""
-%s committed revision %s
+%s r%s : %s
 %s
-""" % (author, revision, comment)).strip()
+""" % (author.strip(), revision, comment.strip(), files)).strip()
   
 	return chatMsg
 

--- a/hipchat-svn-post-commit.py
+++ b/hipchat-svn-post-commit.py
@@ -129,6 +129,7 @@ def main():
     token = TOKEN
     name = NAME
     room = ROOM
+    svn_url = 'http://127.0.0.1/svn/'
 
     # config overrides defaultsif cmd_room:
     if cmd_config:
@@ -144,8 +145,10 @@ def main():
                 token = config.get('hipchat', 'TOKEN')
             if config.has_option('hipchat', 'NAME'):
                 name = config.get('hipchat', 'NAME')
-            if config.has_option('hipchat', 'TOKEN'):
+            if config.has_option('hipchat', 'ROOM'):
                 room = config.get('hipchat', 'ROOM')
+            if config.has_option('hipchat', 'SVN_URL'):
+                room = config.get('hipchat', 'SVN_URL')                 
 
     # cmd line overrides defaults and config
     if cmd_token:
@@ -163,10 +166,8 @@ def main():
         sys.exit(2)
 
     chatMsg = getCommitInfo(repository, revision)
+    sendToHipChat(chatMsg, token, room, name)
 
-    t = threading.Thread(target=sendToHipChat, args=(chatMsg, token, room, name))
-    t.daemon = True
-    t.start()
 
 
 if __name__ == "__main__":

--- a/hipchat-svn-post-commit.py
+++ b/hipchat-svn-post-commit.py
@@ -21,14 +21,17 @@ import urllib
 import urllib2
 import re
 
-# Set hipchat info
-#
-TOKEN="<token>"
-ROOM="<room name>"
-NAME="Subversion"
+# Default room name
+room = "<room name>"
 
-# svnlook location
-LOOK="/usr/bin/svnlook"
+# Default token
+token = "<token>"
+
+# Default chat user name
+user="Subversion"
+
+# Default svnlook location
+svnlook="/usr/bin/svnlook"
 
 ##############################################################
 ##############################################################
@@ -56,7 +59,7 @@ def sendToHipChat( msg, token, room, name ):
 	urllib2.urlopen( "https://api.hipchat.com/v1/rooms/message", urllib.urlencode( request ) )
   
 def runLook( *args ):
-        return subprocess.Popen([LOOK] + list(args), stdout=subprocess.PIPE).stdout.read()
+        return subprocess.Popen([svnlook] + list(args), stdout=subprocess.PIPE).stdout.read()
 
 def getCommitInfo( repo, revision ):
 	comment = runLook("log", repo, "-r", revision)
@@ -74,17 +77,23 @@ def main():
         repository = False
         revision = False
         try:
-                opts, args = getopt.getopt(sys.argv[1:], "r:s:", ["revision=", "repository="])
+                opts, args = getopt.getopt(sys.argv[1:], "r:s:k:t:u:", ["revision=", "repository=", "config=", "room=", "token=", "user="])
         except getopt.GetoptError, err:
                 print >>sys.stderr, str(err)
                 print "Usage:"
-                print "hipchat-svn-post-commit.py -r <revision> -s <repository>"
-                sys.exit(2)
+                print "hipchat-svn-post-commit.py -r <revision> -s <repository> [-k room] [-t token] [-n name]"
+                sys.exit(1)
         for o, a in opts:
                 if o in ("-r", "--revision"):
                        revision = a
                 elif o in ("-s", "--repository"):
                        repository = a
+                elif o in ("-k", "--room"):
+                       room = a
+                elif o in ("-t", "--token"):
+                       token = a
+                elif o in ("-n", "--name"):
+                       name = a
 
         if not revision:
                 print "Sepcify a revision with -r or --revision"
@@ -94,7 +103,7 @@ def main():
                 sys.exit(2)
 
 	chatMsg = getCommitInfo( repository, revision )
-	sendToHipChat( chatMsg, TOKEN, ROOM, NAME )
+	sendToHipChat( chatMsg, token, room, name )
 
 if __name__ == "__main__":
 	main()

--- a/hipchat-svn-post-commit.py
+++ b/hipchat-svn-post-commit.py
@@ -6,7 +6,7 @@
 # svvitale@gmail.com
 
 #
-# Set config values in code, command line, or config file
+# Set config values in code, command line, or config file.
 #
 
 # This script is set to publish information after SVN commits to HipChat. 
@@ -49,114 +49,117 @@ svnlook="/usr/bin/svnlook"
 ##############################################################
 
 def sendToHipChat( msg, token, room, name ):
-	# replace newlines with XHTML <br />
-	msg = msg.replace("\r", "").replace("\n", "<br />")
+    # replace newlines with XHTML <br />
+    msg = msg.replace("\r", "").replace("\n", "<br />")
 
-	# replace bare URLs with real hyperlinks
-	msg = re.sub( r'(?<!href=")((?:https?|ftp|mailto)\:\/\/[^ \n]*)', r'<a href="\1">\1</a>', msg)
+    # replace bare URLs with real hyperlinks
+    msg = re.sub( r'(?<!href=")((?:https?|ftp|mailto)\:\/\/[^ \n]*)', r'<a href="\1">\1</a>', msg)
 
-	# create request dictionary
-	request = {
-		'auth_token': token,
-		'room_id': room,
-		'from': name,
-		'message': msg,
-		'notify': 1,
-	}
+    # create request dictionary
+    request = {
+        'auth_token': token,
+        'room_id': room,
+        'from': name,
+        'message': msg,
+        'notify': 1,
+    }
 
     t = threading.Thread(target=open_url)
     t.daemon = True
     t.start()
 
 def open_url():
-	# urlencode and post
-	urllib2.urlopen( "https://api.hipchat.com/v1/rooms/message", urllib.urlencode( request ) )
+    # urlencode and post
+    urllib2.urlopen( "https://api.hipchat.com/v1/rooms/message", urllib.urlencode( request ) )
   
 def runLook( *args ):
         return subprocess.Popen([svnlook] + list(args), stdout=subprocess.PIPE).stdout.read()
 
 def getCommitInfo( repo, revision ):
-	comment = runLook("log", repo, "-r", revision)
-	author = runLook("author", repo, "-r", revision)
-	files = runLook("changed", repo, "-r", revision)
+    comment = runLook("log", repo, "-r", revision)
+    author = runLook("author", repo, "-r", revision)
+    files = runLook("changed", repo, "-r", revision)
 
-	chatMsg = ("""
+    chatMsg = ("""
 %s r%s : %s
 %s
 """ % (author.strip(), revision, comment.strip(), files)).strip()
   
-	return chatMsg
+    return chatMsg
 
 def main():
-        revision = False
-        repository = False
-        cmd_config = False
-        cmd_token = False
-        cmd_name = False
-        cmd_room = False
+    revision = False
+    repository = False
+    cmd_config = False
+    cmd_token = False
+    cmd_name = False
+    cmd_room = False
 
-        try:
-                opts, args = getopt.getopt(sys.argv[1:], "r:s:f:k:t:u:", ["revision=", "repository=", "config=", "room=", "token=", "user="])
-        except getopt.GetoptError, err:
-                print >>sys.stderr, str(err)
-                print "Usage:"
-                print "hipchat-svn-post-commit.py -r <revision> -s <repository> [-f config] [-k room] [-t token] [-n name]"
-                sys.exit(1)
-        for o, a in opts:
-                if o in ("-r", "--revision"):
-                       revision = a
-                elif o in ("-s", "--repository"):
-                       repository = a
-                elif o in ("-k", "--room"):
-                       cmd_room = a
-                elif o in ("-t", "--token"):
-                       cmd_token = a
-                elif o in ("-n", "--name"):
-                       cmd_name = a
-                elif o in ("-f", "--config"):
-                       cmd_config = a
-                       if not os.path.isfile(cmd_config):
-                                print "Config file does not exist:", cmd_config
-                                sys.exit(2)
-        # set defaults
-        token = TOKEN
-        name = NAME
-        room = ROOM
-
-        # config overrides defaultsif cmd_room:
-        if cmd_config:
-        	     config_file = cmd_config
-       	else:
-        	     config_file = CONFIG
-
-        if os.path.isfile(config_file):
-                config = ConfigParser.ConfigParser()
-                config.read(config_file)
-                if config.has_section('hipchat'):
-                        if config.has_option('hipchat', 'TOKEN'):
-                	            token = config.get('hipchat', 'TOKEN')
-                        if config.has_option('hipchat', 'NAME'):
-                	            name = config.get('hipchat', 'NAME')
-                        if config.has_option('hipchat', 'TOKEN'):
-                	            room = config.get('hipchat', 'ROOM')
-        
-        # cmd line overrides defaults and config
-        if cmd_token:
-        	     token = cmd_token
-        if cmd_name:
-        	     name = cmd_name
-        if cmd_room:
-        	     room = cmd_room
-
-        if not revision:
-                print "Sepcify a revision with -r or --revision"
-                sys.exit(2)
-        if not repository:
-                print "Specify a repository with -s or --repository"
+    try:
+        opts, args = getopt.getopt(
+            sys.argv[1:], "r:s:f:k:t:u:", ["revision=", "repository=", "config=", "room=", "token=", "user="])
+    except getopt.GetoptError, err:
+        print >>sys.stderr, str(err)
+        print "Usage:"
+        print "hipchat-svn-post-commit.py -r <revision> -s <repository> [-f config] [-k room] [-t token] [-n name]"
+        sys.exit(1)
+    for o, a in opts:
+        if o in ("-r", "--revision"):
+            revision = a
+        elif o in ("-s", "--repository"):
+            repository = a
+        elif o in ("-k", "--room"):
+            cmd_room = a
+        elif o in ("-t", "--token"):
+            cmd_token = a
+        elif o in ("-n", "--name"):
+            cmd_name = a
+        elif o in ("-f", "--config"):
+            cmd_config = a
+            if not os.path.isfile(cmd_config):
+                print "Config file does not exist:", cmd_config
                 sys.exit(2)
 
-	chatMsg = getCommitInfo( repository, revision )
-	sendToHipChat( chatMsg, token, room, name )
+    # set defaults
+    token = TOKEN
+    name = NAME
+    room = ROOM
+
+    # config overrides defaultsif cmd_room:
+    if cmd_config:
+        config_file = cmd_config
+    else:
+        config_file = CONFIG
+
+    if os.path.isfile(config_file):
+        config = ConfigParser.ConfigParser()
+        config.read(config_file)
+        if config.has_section('hipchat'):
+            if config.has_option('hipchat', 'TOKEN'):
+                token = config.get('hipchat', 'TOKEN')
+            if config.has_option('hipchat', 'NAME'):
+                name = config.get('hipchat', 'NAME')
+            if config.has_option('hipchat', 'TOKEN'):
+                room = config.get('hipchat', 'ROOM')
+
+    # cmd line overrides defaults and config
+    if cmd_token:
+        token = cmd_token
+    if cmd_name:
+        name = cmd_name
+    if cmd_room:
+        room = cmd_room
+
+    if not revision:
+        print "Sepcify a revision with -r or --revision"
+        sys.exit(2)
+    if not repository:
+        print "Specify a repository with -s or --repository"
+        sys.exit(2)
+
+    chatMsg = getCommitInfo(repository, revision)
+    sendToHipChat(chatMsg, token, room, name)
+
 
 if __name__ == "__main__":
-	main()
+    main()

--- a/hipchat-svn-post-commit.py
+++ b/hipchat-svn-post-commit.py
@@ -66,12 +66,6 @@ def sendToHipChat(msg, token, room, name):
         'notify': 1,
     }
 
-    t = threading.Thread(target=open_url)
-    t.daemon = True
-    t.start()
-
-
-def open_url():
     # urlencode and post
     urllib2.urlopen("https://api.hipchat.com/v1/rooms/message",
                     urllib.urlencode(request))
@@ -165,7 +159,10 @@ def main():
         sys.exit(2)
 
     chatMsg = getCommitInfo(repository, revision)
-    sendToHipChat(chatMsg, token, room, name)
+
+    t = threading.Thread(target=sendToHipChat, args=(chatMsg, token, room, name))
+    t.daemon = True
+    t.start()
 
 
 if __name__ == "__main__":

--- a/hipchat-svn-post-commit.py
+++ b/hipchat-svn-post-commit.py
@@ -80,10 +80,14 @@ def getCommitInfo(repo, revision):
     author = runLook("author", repo, "-r", revision)
     files = runLook("changed", repo, "-r", revision)
 
+
+    url_path = files.split()
+
     chatMsg = ("""
 %s r%s : %s
-%s
-""" % (author.strip(), revision, comment.strip(), files)).strip()
+%s : https://svn.onehippo.org/repos/closed/%s?p=%s
+""" % (author.strip(), revision, comment.strip(), files, url_path[1], revision)).strip()
+
 
     return chatMsg
 

--- a/hipchat-svn-post-commit.py
+++ b/hipchat-svn-post-commit.py
@@ -9,7 +9,7 @@
 # Set config values in code, command line, or config file.
 #
 
-# This script is set to publish information after SVN commits to HipChat. 
+# This script is set to publish information after SVN commits to HipChat.
 #
 # Required files/Application/services:
 #     * Subversion: http://subversion.tigris.org/
@@ -34,26 +34,28 @@ ROOM = "<room name>"
 TOKEN = "<token>"
 
 # Default chat user name
-NAME="Subversion"
+NAME = "Subversion"
 
 # Default config
-CONFIG="/etc/svn/hipchat.cfg"
+CONFIG = "/etc/svn/hipchat.cfg"
 
 # Default svnlook location
-svnlook="/usr/bin/svnlook"
+svnlook = "/usr/bin/svnlook"
 
-##############################################################
-##############################################################
-############ Edit below at your own risk #####################
-##############################################################
-##############################################################
+#
+#
+# Edit below at your own risk #####################
+#
+#
 
-def sendToHipChat( msg, token, room, name ):
+
+def sendToHipChat(msg, token, room, name):
     # replace newlines with XHTML <br />
     msg = msg.replace("\r", "").replace("\n", "<br />")
 
     # replace bare URLs with real hyperlinks
-    msg = re.sub( r'(?<!href=")((?:https?|ftp|mailto)\:\/\/[^ \n]*)', r'<a href="\1">\1</a>', msg)
+    msg = re.sub(
+        r'(?<!href=")((?:https?|ftp|mailto)\:\/\/[^ \n]*)', r'<a href="\1">\1</a>', msg)
 
     # create request dictionary
     request = {
@@ -68,14 +70,18 @@ def sendToHipChat( msg, token, room, name ):
     t.daemon = True
     t.start()
 
+
 def open_url():
     # urlencode and post
-    urllib2.urlopen( "https://api.hipchat.com/v1/rooms/message", urllib.urlencode( request ) )
-  
-def runLook( *args ):
+    urllib2.urlopen("https://api.hipchat.com/v1/rooms/message",
+                    urllib.urlencode(request))
+
+
+def runLook(*args):
         return subprocess.Popen([svnlook] + list(args), stdout=subprocess.PIPE).stdout.read()
 
-def getCommitInfo( repo, revision ):
+
+def getCommitInfo(repo, revision):
     comment = runLook("log", repo, "-r", revision)
     author = runLook("author", repo, "-r", revision)
     files = runLook("changed", repo, "-r", revision)
@@ -84,8 +90,9 @@ def getCommitInfo( repo, revision ):
 %s r%s : %s
 %s
 """ % (author.strip(), revision, comment.strip(), files)).strip()
-  
+
     return chatMsg
+
 
 def main():
     revision = False

--- a/hipchat-svn-post-commit.py
+++ b/hipchat-svn-post-commit.py
@@ -75,18 +75,19 @@ def runLook(*args):
         return subprocess.Popen([svnlook] + list(args), stdout=subprocess.PIPE).stdout.read()
 
 
-def getCommitInfo(repo, revision):
+def getCommitInfo(repo, revision, svn_url):
     comment = runLook("log", repo, "-r", revision)
     author = runLook("author", repo, "-r", revision)
     files = runLook("changed", repo, "-r", revision)
 
 
     url_path = files.split()
+    url = svn_url + "/" + url_path[1]
 
     chatMsg = ("""
 %s r%s : %s
-%s : https://svn.onehippo.org/repos/closed/%s?p=%s
-""" % (author.strip(), revision, comment.strip(), files, url_path[1], revision)).strip()
+%s : %s?p=%s
+""" % (author.strip(), revision, comment.strip(), files, url, revision)).strip()
 
 
     return chatMsg
@@ -148,7 +149,7 @@ def main():
             if config.has_option('hipchat', 'ROOM'):
                 room = config.get('hipchat', 'ROOM')
             if config.has_option('hipchat', 'SVN_URL'):
-                room = config.get('hipchat', 'SVN_URL')                 
+                svn_url = config.get('hipchat', 'SVN_URL')                 
 
     # cmd line overrides defaults and config
     if cmd_token:
@@ -165,7 +166,7 @@ def main():
         print "Specify a repository with -s or --repository"
         sys.exit(2)
 
-    chatMsg = getCommitInfo(repository, revision)
+    chatMsg = getCommitInfo(repository, revision, svn_url)
     sendToHipChat(chatMsg, token, room, name)
 
 

--- a/hipchat.cfg
+++ b/hipchat.cfg
@@ -1,6 +1,6 @@
 [hipchat]
-NAME=
-ROOM=
-TOKEN=
-SVN_URL=
+NAME=subversion
+ROOM=my-company-svn-commits-room
+TOKEN=01234567890
+SVN_URL=http://127.0.0.1/svn
 

--- a/hipchat.cfg
+++ b/hipchat.cfg
@@ -1,0 +1,6 @@
+[hipchat]
+NAME=
+ROOM=
+TOKEN=
+SVN_URL=
+


### PR DESCRIPTION
It's a little bit less nice to use getopts than argparse, but it makes the script compatible with python 2.5 which is commonly installed on older Debian/linux servers.
